### PR TITLE
빈 문자열 분석 후 tokenList를 가져 올 때 발생하는 버그 수정

### DIFF
--- a/core/src/main/java/kr/co/shineware/nlp/komoran/core/Komoran.java
+++ b/core/src/main/java/kr/co/shineware/nlp/komoran/core/Komoran.java
@@ -245,6 +245,12 @@ public class Komoran implements Cloneable {
      */
     public List<KomoranResult> analyze(String sentence, int nbest) {
 
+        if(sentence.length() == 0){
+            return new ArrayList<>(
+                    Collections.singletonList(new KomoranResult(new ArrayList<>(), sentence))
+            );
+        }
+
         Lattice lattice = new Lattice(this.resources, this.userDic, nbest, combinationRuleChecker);
 
         //연속된 숫자, 외래어, 기호 등을 파싱 하기 위한 버퍼

--- a/core/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
+++ b/core/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
@@ -2,6 +2,7 @@ package kr.co.shineware.nlp.komoran.issue;
 
 import kr.co.shineware.nlp.komoran.constant.DEFAULT_MODEL;
 import kr.co.shineware.nlp.komoran.core.Komoran;
+import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,18 @@ public class AnalyzeIssues {
         //TODO : https://github.com/shineware/KOMORAN/issues/94 재밌/VA와 재미있/VA에 대한 올바른 분석 결과가 아님. 테스트 케이스 수정 필요
         assertEqualsOfAnalyzeResult("업데이트했어요ㅋㅋㅋㅋ 재밌네요", "업데이트했어요ㅋㅋㅋㅋ/NA 재미있/VA 네요/EC");
         assertEqualsOfAnalyzeResult("하ㅎ 재밌었어요 캡틴마블", "하/NNG ㅎ/XSV 재미있/VA 었/EP 어요/EC 캡틴/NNG 마블/NNG");
+    }
+
+    @Test
+    //https://github.com/shin285/KOMORAN/issues/119
+    public void issue119() {
+        KomoranResult komoranResult = this.komoran.analyze("");
+        System.out.println(komoranResult.getTokenList());
+        System.out.println(komoranResult.getPlainText());
+        System.out.println(komoranResult.getResultNodeList());
+        System.out.println(komoranResult.getList());
+        System.out.println(komoranResult.getNouns());
+        System.out.println(komoranResult.getMorphesByTags("NNG", "NA"));
     }
 
     @Test

--- a/core/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
+++ b/core/src/test/java/kr/co/shineware/nlp/komoran/issue/AnalyzeIssues.java
@@ -30,12 +30,10 @@ public class AnalyzeIssues {
     //https://github.com/shin285/KOMORAN/issues/119
     public void issue119() {
         KomoranResult komoranResult = this.komoran.analyze("");
-        System.out.println(komoranResult.getTokenList());
-        System.out.println(komoranResult.getPlainText());
-        System.out.println(komoranResult.getResultNodeList());
-        System.out.println(komoranResult.getList());
-        System.out.println(komoranResult.getNouns());
-        System.out.println(komoranResult.getMorphesByTags("NNG", "NA"));
+        Assert.assertEquals(0, komoranResult.getTokenList().size());
+        Assert.assertEquals("", komoranResult.getPlainText());
+        Assert.assertEquals(0, komoranResult.getResultNodeList().size());
+        Assert.assertEquals(0, komoranResult.getList().size());
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈 또는 PR 번호
Resolved #119 

## PR 종류
- [x] 버그 수정

## PR 설명
빈 공백을 마음 껏 분석 할 수 있습니다.
